### PR TITLE
🐛 修复SSH连接空闲超时断开问题

### DIFF
--- a/src/cpolar_connect/ssh.py
+++ b/src/cpolar_connect/ssh.py
@@ -277,7 +277,9 @@ class SSHManager:
             f"\tIdentityFile {self.private_key_path}\n",
             f"\tPreferredAuthentications publickey\n",
             f"\tStrictHostKeyChecking no\n",
-            f"\tUserKnownHostsFile /dev/null\n"
+            f"\tUserKnownHostsFile /dev/null\n",
+            f"\tServerAliveInterval 30\n",
+            f"\tServerAliveCountMax 3\n"
         ]
 
         # Add port forwarding if specified
@@ -321,7 +323,9 @@ class SSHManager:
                 "-i", str(self.private_key_path),
                 "-o", "PreferredAuthentications=publickey",
                 "-o", "StrictHostKeyChecking=no",
-                "-o", "UserKnownHostsFile=/dev/null"
+                "-o", "UserKnownHostsFile=/dev/null",
+                "-o", "ServerAliveInterval=30",
+                "-o", "ServerAliveCountMax=3"
             ]
         else:
             # Use configured alias


### PR DESCRIPTION
## 问题描述

通过 cpolar 隧道建立的 SSH 连接会在空闲一段时间后被远程主机主动关闭，导致用户需要频繁重新连接。

**错误信息：**
```
Connection to 35.tcp.cpolar.top closed by remote host.
Connection to 35.tcp.cpolar.top closed.
```

## 原因分析

SSH 命令缺少 keepalive 配置。cpolar 隧道对空闲连接有超时限制，当没有活动数据包时，隧道会主动断开连接。

## 修复方案

在两处添加 SSH keepalive 配置：

1. **`connect()` 方法**：直接 SSH 命令添加参数
2. **`update_ssh_config()` 方法**：`~/.ssh/config` 配置文件添加选项

**添加的参数：**
- `ServerAliveInterval 30` - 每 30 秒发送一次心跳包
- `ServerAliveCountMax 3` - 允许 3 次心跳失败后才断开

## 效果

SSH 连接将保持活跃，直到用户手动断开（`exit` 或 `Ctrl+C`），不再因空闲超时而自动断开。